### PR TITLE
Google Chrome devチャンネルでsyntax error

### DIFF
--- a/src/background/popup.js
+++ b/src/background/popup.js
@@ -2,7 +2,7 @@
 
 Deferred.debug = true;
 var BG = chrome.extension.getBackgroundPage();
-import(BG, ['UserManager', 'User', 'HTTPCache', 'URI', 'Manager', 'Model']);
+importModules(BG, ['UserManager', 'User', 'HTTPCache', 'URI', 'Manager', 'Model']);
 
 var request_uri = URI.parse('http://chrome/' + location.href);
 var popupMode = request_uri.param('url') ? false : true;

--- a/src/lib/02-Utils.js
+++ b/src/lib/02-Utils.js
@@ -30,7 +30,7 @@ sprintf._SPRINTF_HASH = {
     '%f': parseFloat
 };
 
-var import = function(source, names, target) {
+var importModules = function(source, names, target) {
     if (!target) target = GLOBAL;
     for (var i = 0;  i < names.length; i++) {
         var name = names[i];


### PR DESCRIPTION
Google Chromeのdevチャンネルで，importは予約語であるとして，syntax errorが出て，動かなくなっていました．
importというメソッドが定義されていたのを，importModulesというメソッドにリネームしました．
devチャンネル以外では確認していません．
