### PR TITLE
Twitterからのリンクがコメント一覧の場合に元ページにリダイレクトする設定追加

### DIFF
--- a/src/background/background.js
+++ b/src/background/background.js
@@ -281,6 +281,21 @@ chrome.extension.onConnect.addListener(function(port, name) {
   });
 });
 
+const ENTRY_RE = /^http:\/\/b\.hatena\.ne\.jp\/entry\/(s\/)?/;
+chrome.webRequest.onHeadersReceived.addListener(function(details) {
+    if (!Config.get('background.twitterlink.enabled')) return;
+
+    var headers = details.responseHeaders;
+    headers.forEach(function(header) {
+        if (header.name !== 'Location') return;
+
+        header.value = header.value.replace(ENTRY_RE, function(m, ssl) {
+            return ssl ? 'https://' : 'http://';
+        });
+    });
+    return { responseHeaders: headers };
+}, { urls: ['http://htn.to/*'] }, ['blocking', 'responseHeaders']);
+
 // login check
 setInterval(function() {
     if (isEuraAgreed()) {

--- a/src/background/config-setting.js
+++ b/src/background/config-setting.js
@@ -48,6 +48,7 @@
         'popup.lastView': 'comment',
         'content.webinfo.enabled': true,
         'background.bookmarkcounter.enabled': true,
+        'background.twitterlink.enabled': false
     };
     Object.keys(defaults).forEach(function(key) {
         Config.append(key, defaults[key]);

--- a/src/background/config.html
+++ b/src/background/config.html
@@ -105,6 +105,16 @@
         <label for="background.bookmarkcounter.enabled-disable">ブックマークカウンターを表示しない</label>
       </td>
     </tr>
+    <tr>
+      <th>Twitterリンク</th>
+      <td>
+        <input type="radio" value="1" id="background.twitterlink.enabled-enable" name="background.twitterlink.enabled"/>
+        <label for="background.twitterlink.enabled-enable">Twitterからのリンクがコメント一覧ページだった場合にブックマークされたページを表示する</label>
+        <br>
+        <input type="radio" value="0" id="background.twitterlink.enabled-disable" name="background.twitterlink.enabled"/>
+        <label for="background.twitterlink.enabled-disable">Twitterからのリンクがコメント一覧ページだった場合にコメント一覧ページを表示する</label>
+      </td>
+    </tr>
   </table>
 
   <h2>初期化</h2>

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -9,7 +9,9 @@
     "https://*/*",
     "tabs",
     "bookmarks",
-    "unlimited_storage"
+    "unlimited_storage",
+    "webRequest",
+    "webRequestBlocking"
   ],
   "icons": {
       "16": "images/favicon16.png",


### PR DESCRIPTION
http://bookmark.hatenastaff.com/entry/2013/06/26/214500
こちらの変更によりコメント一覧ページに遷移するようになりましたが、投稿するほうだけでなく、ユーザー側でも選択できるような設定を拡張に追加してみました。

公式に入らないなら別拡張にしてリリースしようと思います。

よろしくお願いします。
