### PR TITLE
google検索結果のbookmark数の部分で改行

### DIFF
--- a/src/main/content/widget_embedder.js
+++ b/src/main/content/widget_embedder.js
@@ -238,11 +238,13 @@ extend(WidgetEmbedder.prototype, {
             style: 'display: none;',
         });
         img.addEventListener('load', this._onImageLoad, false);
-        widgets.appendChild(E('a', {
+        var a = E('a', {
             href: getEntryURL(url),
             title: WidgetEmbedder.messages.SHOW_ENTRY_TITLE,
-            'class': 'hBookmark-widget-counter'
-        }, img));
+            'class': 'hBookmark-widget-counter',
+        }, img);
+        var div = E('div', {}, a);
+        widgets.appendChild(div);
         return widgets;
     },
 


### PR DESCRIPTION
Google検索結果ページで、記事のタイトルが長いと、ブックマーク数の表示が途中で見きれてしまっている。とりあえず~usersの部分をdivで囲うことで改行してみた。

修正前だと下の図の２つめの記事のブックマーク数がわからない。
- 修正前
<img width="691" alt="2016-08-11 21 40 34" src="https://cloud.githubusercontent.com/assets/5510944/17588812/43491a14-600c-11e6-989f-7143d1990df2.png">
- 修正後
<img width="661" alt="2016-08-11 21 40 01" src="https://cloud.githubusercontent.com/assets/5510944/17588821/46c65cec-600c-11e6-968f-8bdce20f647d.png">

~usersの部分は遅延ロードされるので、検索結果が表示された直後に全体が少しずつ下にずれてしまってあまり良くないとは思うが、とりあえず自分用に修正したので、開発の参考にしてください。

---
関係ないですが、Google検索結果の~usersの横に、「この記事は8/11日にブックマークしました。」と表示する機能があると、Googe検索から以前ブックマークした記事にたどり着きやすくなって便利だと思います。
