### PR TITLE
ブックマーク数画像をnetwork-path referenceで表示

### DIFF
--- a/src/main/content/widget_embedder.js
+++ b/src/main/content/widget_embedder.js
@@ -233,7 +233,7 @@ extend(WidgetEmbedder.prototype, {
         var url = link.href;
         var sharpEscapedURL = url.replace(/#/g, '%23');
         var img = E('img', {
-            src: 'http://b.st-hatena.com/entry/image/' + sharpEscapedURL,
+            src: '//b.st-hatena.com/entry/image/' + sharpEscapedURL,
             alt: WidgetEmbedder.messages.SHOW_ENTRY_TEXT,
             style: 'display: none;',
         });


### PR DESCRIPTION
表示中のページがHTTP/HTTPSにかかわらず、HTTPの画像リソースが読み込まれ mixed-content になっています。
そのため、挿入する画像のsrcを network-path reference（ページのschemeに合わせてhttp/httpsを切り替える）のURLに変更しました。

![image](https://cloud.githubusercontent.com/assets/519604/25467845/2496bbba-2b4c-11e7-98d0-cb9b7ef4f671.png)
