### PR TITLE
HTTPS ページのブックマーク数 (拡張アイコン上のバッジテキスト) を表示

### DIFF
--- a/src/main/lib/04-HTTPCache.js
+++ b/src/main/lib/04-HTTPCache.js
@@ -85,15 +85,6 @@ HTTPCache.counter = new HTTPCache('counterCache', {
     encoder: encodeURIComponent,
 });
 
-HTTPCache.counter.isValid = function(url) {
-    // XXX
-    if (url.indexOf('https') == 0) {
-        return false;
-    } else {
-        return true;
-    }
-};
-
 /*
 HTTPCache.counter.createFilter = function(ev) {
     let filters = eval( '(' + HTTPCache.counter.prefs.get('counterIgnoreList') + ')');


### PR DESCRIPTION
HTTPS ページを開いた時に拡張アイコン上にブックマークユーザ数が表示されないため、表示できるようにしました。
近年 HTTPS のページが増えてきており、ユーザ数を表示できるようになれば便利だと思います。

コードを見ると意図的に非表示にしているようにも見えるのですが、
コードが追加された当時のコミットログなどを見ても理由が分かりませんでした。
伏せてご確認いただけると幸いです。